### PR TITLE
Add power cycling with reboot; check binaries locations

### DIFF
--- a/Startup/settings.bash
+++ b/Startup/settings.bash
@@ -11,11 +11,13 @@ RM_BIN=/bin/rm
 CUT_BIN=/usr/bin/cut
 ECHO_BIN=/bin/echo
 TEE_BIN=/usr/bin/tee
+# Have to add screen to image
 SCREEN_BIN=/usr/bin/screen
 SLEEP_BIN=/bin/sleep
 LS_BIN=/bin/ls
-READLINK="/bin/readlink -f"
+READLINK="/usr/bin/readlink -f"
 DATE_BIN="/bin/date +%s.%3N"
+REBOOT_BIN=/sbin/reboot
 
 # locations of files
 VERBOSITY=/seq/verbosity.bash

--- a/Startup/startup.bash
+++ b/Startup/startup.bash
@@ -36,7 +36,7 @@ BOOT_COUNTER_RTN=$(($BOOT_COUNTER_RTN % 10))
 
 $SLEEP_BIN $INHIBIT_COOKIE_TIMEOUT
 if [ -f "$INHIBIT_COOKIE" ]; then
-  rm $INHIBIT_COOKIE 2> /dev/null || evr 1 "failed to remove $INHIBIT_COOKIE"
+  rm $INHIBIT_COOKIE 2> /dev/null || evr 1 "failedv to remove $INHIBIT_COOKIE"
   evr 1 "$INHIBIT_COOKIE present; not running FSW"
   fail_signify_action &
   wait $!
@@ -81,8 +81,11 @@ if (( $? == 0 )); then
   evr 3 "running CURRENT $DEPLOYMENT"
   $SCREEN_BIN -D -m -S CURRENT bash -c \
       "( $BIN_DEREF $FSW_ARGS | $TEE_BIN ${STDOUT_LOG}$BOOT_COUNTER_RTN ) 3>&1 1>&2 2>&3 | $TEE_BIN ${STDERR_LOG}$BOOT_COUNTER_RTN"
-  # NOTE(mereweth) - if we get here, then we crashed - FPGA powers us off
+  # NOTE(mereweth) - if we get here, then we crashed
   evr 1 "CURRENT failed $BIN_DEREF"
+  evr 1 "Power cycling in 10 seconds"
+  $SLEEP_BIN 10
+  $REBOOT_BIN
 fi
 evr 3 "after trying CURRENT"
 


### PR DESCRIPTION
Initial updates for the GuaraniSat-2 project. Checking binaries that they exist and changing the location of binaries to match the current image and changing the power cycling in start-up. Working on a new branch for gsat; should this be moved to a new branch in the repo?